### PR TITLE
Define and implement TNode API

### DIFF
--- a/src/integration_testing/src/TestFrontEnd.cpp
+++ b/src/integration_testing/src/TestFrontEnd.cpp
@@ -7,7 +7,6 @@ void require(bool b) {
 
 TEST_CASE("1st Test") {
 
-    TNode T;
     require(1 == 1);
 }
 

--- a/src/spa/src/TNode.cpp
+++ b/src/spa/src/TNode.cpp
@@ -1,1 +1,13 @@
 #include "TNode.h"
+
+
+TNode::TNode(TNodeType type, string name) {
+	this->type = type;
+	this->name = name;
+}
+
+TNode::~TNode() {}
+
+void TNode::addChildren(TNode* child) {
+	children.push_back(child);
+}

--- a/src/spa/src/TNode.h
+++ b/src/spa/src/TNode.h
@@ -1,5 +1,43 @@
-class TNode
-{
-public:
+#pragma once
 
+#include <vector>
+#include <string>
+
+using std::vector;
+using std::string;
+
+enum class TNodeType
+{
+	Program,
+	Procedure,
+	If,
+	Then,
+	Else,
+	While,
+	Variable,
+	Constant,
+	StmtLst,
+	Assign,
+	Call,
+	SemiColon,
+	CurlyBraceOpen,
+	CurlyBraceClose,
+	Equals,
+	Plus,
+	Minus,
+	Times,
+	Divide,
+	Mod
+};
+
+class TNode {
+public:
+	TNode(TNodeType, string);
+	~TNode();
+	void addChildren(TNode*);
+
+private:
+	TNodeType type;
+	string name;
+	vector<TNode*> children;
 };

--- a/src/unit_testing/src/TestAST.cpp
+++ b/src/unit_testing/src/TestAST.cpp
@@ -8,10 +8,6 @@ void require(bool b) {
 }
 
 TEST_CASE("1st Test") {
-
-    TNode T;
-	
-	
 	
     require(1 == 1);
 }


### PR DESCRIPTION
Current implementation uses `vector<TNode*>` data structure to store children of a particular `TNode`. 

Closes #14.